### PR TITLE
Feat/migrate 2.8.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.6.4
-starknet-foundry 0.22.0
+scarb 2.8.3
+starknet-foundry 0.31.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.8.3
+scarb 2.8.2
 starknet-foundry 0.31.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -7,9 +7,19 @@ version = "0.12.0"
 source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.12.0#0697004db74502ce49900edef37331dd03531356"
 
 [[package]]
+name = "snforge_scarb_plugin"
+version = "0.31.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:1fce075fcbf7fce1b0935f6f9a034549704837fb221da212d3b6e9134cebfdaa"
+
+[[package]]
 name = "snforge_std"
-version = "0.22.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.22.0#9b215944c6c5871c738381b4ded61bbf06e7ba35"
+version = "0.31.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:60ac980b297281f9a59a5f1668cb56bdea1b28fd2f8008008270f9a3c91ad3ba"
+dependencies = [
+ "snforge_scarb_plugin",
+]
 
 [[package]]
 name = "token_bound_accounts"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,8 +2,8 @@
 name = "tokengiver"
 version = "0.1.0"
 edition = "2024_07"
-cairo-version = "2.8.3"
-scarb-version = "2.8.3"
+cairo-version = "2.8.2"
+scarb-version = "2.8.2"
 authors = ["Oshioke Salaki & Stephanie Egbuonu"]
 description = "Decentralized Charity Dapp"
 keywords = ["SocialFi", "tokenbound", "cairo", "contracts", "starknet"]
@@ -11,17 +11,11 @@ keywords = ["SocialFi", "tokenbound", "cairo", "contracts", "starknet"]
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.8.3"
-openzeppelin_access = "0.18.0"
-openzeppelin_introspection = "0.18.0"
-openzeppelin_token = "0.18.0"
+starknet = "2.8.2"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.12.0" }
 token_bound_accounts= { git = "https://github.com/Starknet-Africa-Edu/TBA", tag = "v0.3.0" }
 
 [dev-dependencies]
-assert_macros = "2.8.3"
-openzeppelin_utils = "0.18.0"
-openzeppelin_testing = "0.18.0"
 snforge_std = "0.31.0"
 
 [[target.starknet-contract]]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,9 @@
 [package]
 name = "tokengiver"
 version = "0.1.0"
-edition = "2023_10"
+edition = "2024_07"
+cairo-version = "2.8.3"
+scarb-version = "2.8.3"
 authors = ["Oshioke Salaki & Stephanie Egbuonu"]
 description = "Decentralized Charity Dapp"
 keywords = ["SocialFi", "tokenbound", "cairo", "contracts", "starknet"]
@@ -9,12 +11,18 @@ keywords = ["SocialFi", "tokenbound", "cairo", "contracts", "starknet"]
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.6.3"
+starknet = "2.8.3"
+openzeppelin_access = "0.18.0"
+openzeppelin_introspection = "0.18.0"
+openzeppelin_token = "0.18.0"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.12.0" }
 token_bound_accounts= { git = "https://github.com/Starknet-Africa-Edu/TBA", tag = "v0.3.0" }
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.22.0" }
+assert_macros = "2.8.3"
+openzeppelin_utils = "0.18.0"
+openzeppelin_testing = "0.18.0"
+snforge_std = "0.31.0"
 
 [[target.starknet-contract]]
 casm = true

--- a/src/base/types.cairo
+++ b/src/base/types.cairo
@@ -12,7 +12,7 @@ use starknet::ContractAddress;
 // displayed name, description, beneficiary, etc.
 #[derive(Drop, Serde, starknet::Store)]
 pub struct Campaign {
-    campaign_address: ContractAddress,
-    campaign_owner: ContractAddress,
-    metadata_URI: ByteArray,
+    pub campaign_address: ContractAddress,
+    pub campaign_owner: ContractAddress,
+    pub metadata_URI: ByteArray,
 }

--- a/src/campaign.cairo
+++ b/src/campaign.cairo
@@ -5,10 +5,8 @@ pub mod CampaignComponent {
     // *************************************************************************
     use core::traits::TryInto;
     use starknet::{
-        ContractAddress, get_caller_address, 
-        storage::{
-            Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess
-        }
+        ContractAddress, get_caller_address,
+        storage::{Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess}
     };
     use tokengiver::interfaces::ITokenGiverNft::{
         ITokenGiverNftDispatcher, ITokenGiverNftDispatcherTrait
@@ -168,13 +166,12 @@ pub mod CampaignComponent {
             let count = self.count.read();
             let mut i: u16 = 1;
 
-            while i < count
-                + 1 {
-                    let campaignAddress: ContractAddress = self.campaigns.entry(i).read();
-                    let campaign: Campaign = self.campaign.entry(campaignAddress).read();
-                    campaigns.append(campaign.metadata_URI);
-                    i += 1;
-                };
+            while i < count + 1 {
+                let campaignAddress: ContractAddress = self.campaigns.entry(i).read();
+                let campaign: Campaign = self.campaign.entry(campaignAddress).read();
+                campaigns.append(campaign.metadata_URI);
+                i += 1;
+            };
             campaigns
         }
 
@@ -185,15 +182,14 @@ pub mod CampaignComponent {
             let count = self.count.read();
             let mut i: u16 = 1;
 
-            while i < count
-                + 1 {
-                    let campaignAddress: ContractAddress = self.campaigns.entry(i).read();
-                    let campaign: Campaign = self.campaign.entry(campaignAddress).read();
-                    if campaign.campaign_owner == user {
-                        campaigns.append(campaign.metadata_URI);
-                    }
-                    i += 1;
-                };
+            while i < count + 1 {
+                let campaignAddress: ContractAddress = self.campaigns.entry(i).read();
+                let campaign: Campaign = self.campaign.entry(campaignAddress).read();
+                if campaign.campaign_owner == user {
+                    campaigns.append(campaign.metadata_URI);
+                }
+                i += 1;
+            };
             campaigns
         }
 

--- a/src/presets/campaign.cairo
+++ b/src/presets/campaign.cairo
@@ -1,5 +1,5 @@
 #[starknet::contract]
-mod TokenGiverCampaign {
+pub mod TokenGiverCampaign {
     use starknet::{ContractAddress, get_caller_address};
     use tokengiver::campaign::CampaignComponent;
 
@@ -9,14 +9,14 @@ mod TokenGiverCampaign {
     impl CampaignImpl = CampaignComponent::TokenGiverCampaign<ContractState>;
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
         campaign: CampaignComponent::Storage
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
-    enum Event {
+    pub enum Event {
         #[flat]
         CampaignEvent: CampaignComponent::Event
     }

--- a/src/token_giver_nft.cairo
+++ b/src/token_giver_nft.cairo
@@ -36,10 +36,9 @@ pub mod TokenGiverNFT {
     //                             IMPORTS
     // *************************************************************************
     use openzeppelin::token::erc721::interface::IERC721Metadata;
-    use starknet::{ContractAddress, get_caller_address, get_block_timestamp,
-        storage::{
-            Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess
-        }
+    use starknet::{
+        ContractAddress, get_caller_address, get_block_timestamp,
+        storage::{Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess}
     };
     use core::num::traits::zero::Zero;
     use tokengiver::interfaces::ITokenGiverNft;


### PR DESCRIPTION
Fixes #1 

was migrated to 2.8.2 instead of 2.8.3 because of dependency `token_bound_accounts`  requires 2.8.2 and not higher
