### PR TITLE
enh: apply to campaign pool with Unit tests

### DIFF
--- a/src/base/errors.cairo
+++ b/src/base/errors.cairo
@@ -10,4 +10,7 @@ pub mod Errors {
     pub const INVALID_CAMPAIGN: felt252 = 'TGN: campaign is not owner!';
     pub const INSUFFICIENT_BALANCE: felt252 = 'TGN: insufficient balance!';
     pub const TRANSFER_FAILED: felt252 = 'TGN: transfer failed!';
+    pub const INVALID_CAMPAIGN_ADDRESS: felt252 = 'TGN: invalid campaign address!';
+    pub const INVALID_POOL_ADDRESS: felt252 = 'TGN: invalid pool address!';
+    pub const INVALID_AMOUNT: felt252 = 'TGN: invalid amount!';
 }

--- a/src/interfaces/ICampaignPool.cairo
+++ b/src/interfaces/ICampaignPool.cairo
@@ -26,4 +26,8 @@ pub trait ICampaignPool<TState> {
         amount: u256
     );
     fn upgrade(ref self: TState, new_class_hash: ClassHash);
+
+    fn get_campaign_application(
+        self: @TState, campaign_address: ContractAddress
+    ) -> (ContractAddress, u256);
 }


### PR DESCRIPTION
closes #59 

Added validation and storage logic for campaign pool applications with event emission, along with comprehensive test cases to verify correct functionality and error handling.