### PR TITLE
Added Voting Mechanism for Campaigns

### DIFF
--- a/src/interfaces/ICampaign.cairo
+++ b/src/interfaces/ICampaign.cairo
@@ -21,6 +21,9 @@ pub trait ICampaign<TState> {
     fn set_donations(ref self: TState, campaign_address: ContractAddress, amount: u256);
     fn donate(ref self: TState, campaign_address: ContractAddress, amount: u256, token_id: u256);
     fn withdraw(ref self: TState, campaign_address: ContractAddress, amount: u256);
+    fn vote_project(
+        ref self: TState, campaign_pool_address: ContractAddress, campaign_address: ContractAddress
+    );
 
 
     // Getters


### PR DESCRIPTION
Implemented the vote_project function to allow donors to vote for campaigns.

Ensured only donors (users who have made a donation) can vote.

Tracked votes using donor_votes and updated campaign_votes_count accordingly.

Emitted a DonorVoted event to log each vote.

Included checks to prevent non-donors from voting and to validate donor participation.